### PR TITLE
Apply readable styles to datalist input

### DIFF
--- a/stylesheet/mobileApp.css
+++ b/stylesheet/mobileApp.css
@@ -333,6 +333,12 @@ div#options h2 a {
 				-webkit-appearance: textarea;
 				}
 
+			ul li input[list] {
+				color: #000;
+				background-color: #fff;
+				opacity: 1;
+			}
+
 				ul li textarea {
 					height: 120px;
 					padding: 0;


### PR DESCRIPTION
- Added CSS rules for `ul li input[list]` in `stylesheet/mobileApp.css` to enforce a solid white background and black text color.
- This ensures the exercise key dropdown datalist is readable and matches the theme of other inputs in the app without inheriting unintended transparency.